### PR TITLE
Add support for npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "css",
     "framework"
   ],
-  "author": "",
   "license": "apache",
   "bugs": {
     "url": "https://github.com/buildingfirefoxos/Building-Blocks/issues"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "firefox-os-building-blocks",
+  "version": "1.2.1",
+  "description": "Building blocks for Firefox OS",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/buildingfirefoxos/Building-Blocks.git"
+  },
+  "keywords": [
+    "firefox",
+    "firefox",
+    "os",
+    "building",
+    "blocks",
+    "css",
+    "framework"
+  ],
+  "author": "",
+  "license": "apache",
+  "bugs": {
+    "url": "https://github.com/buildingfirefoxos/Building-Blocks/issues"
+  },
+  "homepage": "http://buildingfirefoxos.com/"
+}


### PR DESCRIPTION
Adding a minimal `package.json` file makes it possible to download these building blocks via [npm](http://npmjs.com). It is not neccessary to publish it to npm itself.
