### PR TITLE
Update bower instructions to install latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Install
 
 1. You can git clone the code from github `https://github.com/buildingfirefoxos/Building-Blocks.git`
 
-2. Or if you have bower installed ([http://bower.io/](http://bower.io/)), run command: `$ bower install building-blocks`
+2. Or if you have bower installed ([http://bower.io/](http://bower.io/)), run command: `$ bower install building-blocks#gh-pages`
 
 
 Contact a human


### PR DESCRIPTION
Installation via github will pull the latest building blocks. The website also
shows the latest version of Building-Blocks. Therefore the bower instructions
should also install the latest version.

I ran into this issue while trying to work with BuildingBlocks to create my
own apps and was confused why the visual styles were not the same as the one
on the website. It took me quite some time to narrow down the issue to bower
installing the latest tagged release rather than the latest commit.
